### PR TITLE
Fix zcat can't stat error

### DIFF
--- a/bin/tech_check_parse.sh
+++ b/bin/tech_check_parse.sh
@@ -24,7 +24,7 @@ _messages_parse() {
   # Would be nice if zcat didn't care if the file were compressed or not, like zgrep
   # Be more like zgrep, zcat
   if [[ $_messages_gz ]]; then
-    zcat "$_messages_gz" | gawk 'BEGIN{IGNORECASE=1} $5 ~ "puppet" { err = substr($0, index($0, $6)); if (err ~ /(error|failure|severe|exception)/) print err }'
+    gunzip -c "$_messages_gz" | gawk 'BEGIN{IGNORECASE=1} $5 ~ "puppet" { err = substr($0, index($0, $6)); if (err ~ /(error|failure|severe|exception)/) print err }'
   elif [[ $_messages ]]; then
     gawk 'BEGIN{IGNORECASE=1} $5 ~ "puppet" { err = substr($0, index($0, $6)); if (err ~ /(error|fail|severe|exception)/) print err }' "$_messages"
   else


### PR DESCRIPTION
Replacing ``zcat`` with ``gunzip -c`` fixes the error as detailed below

```bash
➜  42993 git:(master) ✗ support_parse.sh tech_check puppet_enterprise_support_42993_lxpr0728pv_20210202135239
zcat: can't stat: puppet_enterprise_support_42993_lxpr0728pv_20210202135239/logs/messages.gz (puppet_enterprise_support_42993_lxpr0728pv_20210202135239/logs/messages.gz.Z): No such file or directory
{
  "Server Version": "2019.8.1",
  "Infrastructure": [
    {
      "display_name": "File Sync Client Service",
      "server": "lxpr0721pv.unix.intra.bdf.local",
      "state": "running"
    },
    {
      "display_name": "Puppet Server",
      "server": "lxpr0721pv.unix.intra.bdf.local",
      "state": "running"
    },
    {
      "display_name": "PuppetDB",
      "server": "lxpr0721pv.unix.intra.bdf.local",
      "state": "running"
    },
    {
      "display_name": "File Sync Client Service",
      "server": "lxpr0722pv.unix.intra.bdf.local",
      "state": "running"
    },
```

AFTER the PR fix:

```bash
➜  42993 git:(master) ✗ support_parse.sh tech_check puppet_enterprise_support_42993_lxpr0728pv_20210202135239      
{
  "Server Version": "2019.8.1",
  "Infrastructure": [
    {
      "display_name": "File Sync Client Service",
      "server": "lxpr0721pv.unix.intra.bdf.local",
      "state": "running"
    },
    {
      "display_name": "Puppet Server",
      "server": "lxpr0721pv.unix.intra.bdf.local",
      "state": "running"
    },
    {
      "display_name": "PuppetDB",
```
